### PR TITLE
feat: fix `silent` and enable logging

### DIFF
--- a/crates/core/src/cpu/backend.rs
+++ b/crates/core/src/cpu/backend.rs
@@ -80,7 +80,7 @@ impl CPUBackend {
         }
         let optimizer = CPUOptimizer::from(config.optimizer.clone(), &mut layers);
         let cost = CPUCost::from(config.cost.clone());
-        let silent = config.silent.is_some();
+        let silent = config.silent.is_some_and(|x| x == true);
         Self {
             logger,
             silent,
@@ -121,12 +121,10 @@ impl CPUBackend {
                 self.optimizer.update_grads(&mut self.layers, rate);
                 total += (self.cost.cost)(outputs.view(), dataset.outputs.view());
                 let minibatch = outputs.dim()[0];
-                if !self.silent && (i * minibatch) % batches == 0 {
+                if !self.silent && ((i + 1) * minibatch) % batches == 0 {
                     let cost = total / (batches) as f32;
                     let msg = format!("Epoch={}, Dataset={}, Cost={}", epoch, i * minibatch, cost);
-                    if i != 0 {
-                        (self.logger.log)(msg);
-                    }
+                    (self.logger.log)(msg);
                     total = 0.0;
                 }
             }


### PR DESCRIPTION
This PR fixes the `silent` option defaulting to `true` if the `silent` parameter has a value, even if it is `false`.

This also enables logging on the first dataset if `silent` is false.