### PR TITLE
feat: Compatibility with `@lala/appraisal`

### DIFF
--- a/examples/mnist/predict.ts
+++ b/examples/mnist/predict.ts
@@ -32,7 +32,7 @@ let correct = 0;
 for (const test of testSet) {
   const prediction = argmax(
     await network.predict(
-      tensor(test.inputs.data, [1, ...test.inputs.shape] as Shape[keyof Shape]),
+      tensor(test.inputs.data, [1, ...test.inputs.shape] as Shape<Rank>),
     ),
   );
   const expected = argmax(test.outputs as Tensor<Rank>);

--- a/src/backends/cpu/backend.ts
+++ b/src/backends/cpu/backend.ts
@@ -16,12 +16,12 @@ import {
  */
 export class CPUBackend implements Backend {
   library: Library;
-  outputShape: Shape[Rank];
+  outputShape: Shape<Rank>;
   #id: bigint;
 
   constructor(
     library: Library,
-    outputShape: Shape[Rank],
+    outputShape: Shape<Rank>,
     id: bigint,
   ) {
     this.library = library;
@@ -39,7 +39,7 @@ export class CPUBackend implements Backend {
     ) as bigint;
     const outputShape = Array.from(
       new Uint32Array(shape.buffer.slice(4).buffer),
-    ) as Shape[Rank];
+    ) as Shape<Rank>;
     return new CPUBackend(library, outputShape, id);
   }
 
@@ -72,13 +72,13 @@ export class CPUBackend implements Backend {
   async predict(
     input: Tensor<Rank>,
     layers: number[],
-    outputShape: Shape[keyof Shape],
+    outputShape: Shape<Rank>,
   ): Promise<Tensor<Rank>>;
   //deno-lint-ignore require-await
   async predict(
     input: Tensor<Rank>,
     layers?: number[],
-    outputShape?: Shape[keyof Shape],
+    outputShape?: Shape<Rank>,
   ): Promise<Tensor<Rank>> {
     const options = encodeJSON({
       inputShape: input.shape,
@@ -100,7 +100,7 @@ export class CPUBackend implements Backend {
       [
         input.shape[0],
         ...(outputShape ?? this.outputShape),
-      ] as Shape[keyof Shape],
+      ] as Shape<Rank>,
     );
   }
 
@@ -121,7 +121,7 @@ export class CPUBackend implements Backend {
       buffer.length,
       shape.allocBuffer,
     ) as bigint;
-    const outputShape = Array.from(shape.buffer.slice(1)) as Shape[Rank];
+    const outputShape = Array.from(shape.buffer.slice(1)) as Shape<Rank>;
 
     return new CPUBackend(library, outputShape, id);
   }

--- a/src/backends/cpu/util.ts
+++ b/src/backends/cpu/util.ts
@@ -20,8 +20,8 @@ export class Buffer {
  */
 export type TrainOptions = {
   datasets: number;
-  inputShape: Shape[Rank];
-  outputShape: Shape[Rank];
+  inputShape: Shape<Rank>;
+  outputShape: Shape<Rank>;
   epochs: number;
   batches: number;
   rate: number;
@@ -31,8 +31,8 @@ export type TrainOptions = {
  * Predict Options Interface.
  */
 export type PredictOptions = {
-  inputShape: Shape[Rank];
-  outputShape: Shape[Rank];
+  inputShape: Shape<Rank>;
+  outputShape: Shape<Rank>;
 };
 
 /**

--- a/src/backends/gpu/backend.ts
+++ b/src/backends/gpu/backend.ts
@@ -16,10 +16,10 @@ import {
  */
 export class GPUBackend implements Backend {
   library: Library;
-  outputShape: Shape[Rank];
+  outputShape: Shape<Rank>;
   #id: bigint;
 
-  constructor(library: Library, outputShape: Shape[Rank], id: bigint) {
+  constructor(library: Library, outputShape: Shape<Rank>, id: bigint) {
     this.library = library;
     this.outputShape = outputShape;
     this.#id = id;
@@ -33,7 +33,7 @@ export class GPUBackend implements Backend {
       buffer.length,
       shape.allocBuffer,
     ) as bigint;
-    const outputShape = Array.from(shape.buffer.slice(1)) as Shape[Rank];
+    const outputShape = Array.from(shape.buffer.slice(1)) as Shape<Rank>;
 
     return new GPUBackend(library, outputShape, id);
   }
@@ -67,13 +67,13 @@ export class GPUBackend implements Backend {
   async predict(
     input: Tensor<Rank>,
     layers: number[],
-    outputShape: Shape[keyof Shape],
+    outputShape: Shape<Rank>,
   ): Promise<Tensor<Rank>>;
   //deno-lint-ignore require-await
   async predict(
     input: Tensor<Rank>,
     layers?: number[],
-    outputShape?: Shape[keyof Shape],
+    outputShape?: Shape<Rank>,
   ): Promise<Tensor<Rank>> {
     const options = encodeJSON({
       inputShape: input.shape,
@@ -95,7 +95,7 @@ export class GPUBackend implements Backend {
       [
         input.shape[0],
         ...(outputShape ?? this.outputShape),
-      ] as Shape[keyof Shape],
+      ] as Shape<Rank>,
     );
   }
 
@@ -116,7 +116,7 @@ export class GPUBackend implements Backend {
       buffer.length,
       shape.allocBuffer,
     ) as bigint;
-    const outputShape = Array.from(shape.buffer.slice(1)) as Shape[Rank];
+    const outputShape = Array.from(shape.buffer.slice(1)) as Shape<Rank>;
 
     return new GPUBackend(library, outputShape, id);
   }

--- a/src/backends/gpu/util.ts
+++ b/src/backends/gpu/util.ts
@@ -17,8 +17,8 @@ export class Buffer {
  */
 export type TrainOptions = {
   datasets: number;
-  inputShape: Shape[Rank];
-  outputShape: Shape[Rank];
+  inputShape: Shape<Rank>;
+  outputShape: Shape<Rank>;
   epochs: number;
   batches: number;
   rate: number;
@@ -28,8 +28,8 @@ export type TrainOptions = {
  * Predict Options Interface.
  */
 export type PredictOptions = {
-  inputShape: Shape[Rank];
-  outputShape: Shape[Rank];
+  inputShape: Shape<Rank>;
+  outputShape: Shape<Rank>;
 };
 
 /**

--- a/src/backends/wasm/backend.ts
+++ b/src/backends/wasm/backend.ts
@@ -14,10 +14,10 @@ import { PredictOptions, TrainOptions } from "./utils.ts";
  * Web Assembly Backend.
  */
 export class WASMBackend implements Backend {
-  outputShape: Shape[Rank];
+  outputShape: Shape<Rank>;
   #id: number;
 
-  constructor(outputShape: Shape[Rank], id: number) {
+  constructor(outputShape: Shape<Rank>, id: number) {
     this.outputShape = outputShape;
     this.#id = id;
   }
@@ -25,11 +25,11 @@ export class WASMBackend implements Backend {
   static create(config: NetworkConfig): WASMBackend {
     const shape = Array(0);
     const id = wasm_backend_create(JSON.stringify(config), shape);
-    return new WASMBackend(shape as Shape[Rank], id);
+    return new WASMBackend(shape as Shape<Rank>, id);
   }
 
   train(datasets: DataSet[], epochs: number, batches: number, rate: number): void {
-    this.outputShape = datasets[0].outputs.shape.slice(1) as Shape[Rank];
+    this.outputShape = datasets[0].outputs.shape.slice(1) as Shape<Rank>;
     const buffer = [];
     for (const dataset of datasets) {
       buffer.push(dataset.inputs.data as Float32Array);
@@ -76,6 +76,6 @@ export class WASMBackend implements Backend {
   static load(input: Uint8Array): WASMBackend {
     const shape = Array(0);
     const id = wasm_backend_load(input, shape);
-    return new WASMBackend(shape as Shape[Rank], id);
+    return new WASMBackend(shape as Shape<Rank>, id);
   }
 }

--- a/src/backends/wasm/utils.ts
+++ b/src/backends/wasm/utils.ts
@@ -5,8 +5,8 @@ import { Rank, Shape } from "../../core/api/shape.ts";
  */
 export type TrainOptions = {
   datasets: number;
-  inputShape: Shape[Rank];
-  outputShape: Shape[Rank];
+  inputShape: Shape<Rank>;
+  outputShape: Shape<Rank>;
   epochs: number;
   batches: number;
   rate: number;
@@ -16,6 +16,6 @@ export type TrainOptions = {
  * Predict Options Interface.
  */
 export type PredictOptions = {
-  inputShape: Shape[Rank];
-  outputShape: Shape[Rank];
+  inputShape: Shape<Rank>;
+  outputShape: Shape<Rank>;
 };

--- a/src/core/api/error.ts
+++ b/src/core/api/error.ts
@@ -16,7 +16,7 @@ export class IncompatibleRankError extends Error {
  * Invalid Flatten Error is thrown when a tensor cannot be flattened.
  */
 export class InvalidFlattenError extends Error {
-  constructor(input: Shape[Rank], output: Shape[Rank]) {
+  constructor(input: Shape<Rank>, output: Shape<Rank>) {
     super(`Cannot flatten tensor of shape ${input} to shape ${output}`);
   }
 }
@@ -36,7 +36,7 @@ export class NoBackendError extends Error {
  * Invalid Pool Error is thrown when a tensor cannot be pooled.
  */
 export class InvalidPoolError extends Error {
-  constructor(size: Shape[Rank], stride: Shape2D) {
+  constructor(size: Shape<Rank>, stride: Shape2D) {
     super(`Cannot pool shape ${size} with stride ${stride}`);
   }
 }

--- a/src/core/api/layer.ts
+++ b/src/core/api/layer.ts
@@ -147,7 +147,7 @@ export type FlattenLayerConfig = {
   /**
    * The size of the layer.
    */
-  size: Shape[Rank];
+  size: Shape<Rank>;
 };
 
 /**

--- a/src/core/api/shape.ts
+++ b/src/core/api/shape.ts
@@ -1,32 +1,36 @@
 /**
+ * Shape Type
+ */
+export type Shape<R extends Rank> = [number, ...number[]] & { length: R };
+/**
  * 1st dimentional shape.
  */
-export type Shape1D = [number];
+export type Shape1D = Shape<1>;
 
 /**
  * 2nd dimentional shape.
  */
-export type Shape2D = [number, number];
+export type Shape2D = Shape<2>;
 
 /**
  * 3th dimentional shape.
  */
-export type Shape3D = [number, number, number];
+export type Shape3D = Shape<3>;
 
 /**
  * 4th dimentional shape.
  */
-export type Shape4D = [number, number, number, number];
+export type Shape4D = Shape<4>;
 
 /**
  * 5th dimentional shape.
  */
-export type Shape5D = [number, number, number, number, number];
+export type Shape5D = Shape<5>;
 
 /**
  * 6th dimentional shape.
  */
-export type Shape6D = [number, number, number, number, number, number];
+export type Shape6D = Shape<6>;
 
 /**
  * Rank Types.
@@ -61,18 +65,6 @@ export enum Rank {
    * Rank 6 Tensor
    */
   R6 = 6,
-}
-
-/**
- * Shape Interface
- */
-export interface Shape {
-  1: Shape1D;
-  2: Shape2D;
-  3: Shape3D;
-  4: Shape4D;
-  5: Shape5D;
-  6: Shape6D;
 }
 
 /**

--- a/src/core/tensor/util.ts
+++ b/src/core/tensor/util.ts
@@ -24,7 +24,7 @@ export function inferShape(arr: ArrayMap): number[] {
 /**
  * return the length of a shape.
  */
-export function length(shape: Shape[Rank]): number {
+export function length(shape: Shape<Rank>): number {
   let length = 1;
   shape.forEach((i) => length *= i);
   return length;
@@ -33,7 +33,7 @@ export function length(shape: Shape[Rank]): number {
 /**
  * convert a shape to a given rank.
  */
-export function toShape<R extends Rank>(shape: Shape[Rank], rank: R): Shape[R] {
+export function toShape<R extends Rank>(shape: Shape<Rank>, rank: R): Shape<R> {
   if (rank < shape.length) {
     const res = new Array(rank).fill(1);
     for (let i = 1; i < shape.length + 1; i++) {
@@ -43,43 +43,43 @@ export function toShape<R extends Rank>(shape: Shape[Rank], rank: R): Shape[R] {
         res[0] *= shape[shape.length - i];
       }
     }
-    return res as Shape[R];
+    return res as Shape<R>;
   } else if (rank > shape.length) {
     const res = new Array(rank).fill(1);
     for (let i = 1; i < shape.length + 1; i++) {
       res[rank - i] = shape[shape.length - i];
     }
-    return res as Shape[R];
+    return res as Shape<R>;
   } else {
-    return shape as Shape[R];
+    return shape as Shape<R>;
   }
 }
 
 /**
  * convert a shape to a 1D shape.
  */
-export function to1D(shape: Shape[Rank]): Shape[1] {
+export function to1D(shape: Shape<Rank>): Shape<1> {
   return toShape(shape, Rank.R1);
 }
 
 /**
  * convert a shape to a 2D shape.
  */
-export function to2D(shape: Shape[Rank]): Shape[2] {
+export function to2D(shape: Shape<Rank>): Shape<2> {
   return toShape(shape, Rank.R2);
 }
 
 /**
  * convert a shape to a 3D shape.
  */
-export function to3D(shape: Shape[Rank]): Shape[3] {
+export function to3D(shape: Shape<Rank>): Shape<3> {
   return toShape(shape, Rank.R3);
 }
 
 /**
  * convert a shape to a 4D shape.
  */
-export function to4D(shape: Shape[Rank]): Shape[4] {
+export function to4D(shape: Shape<Rank>): Shape<4> {
   return toShape(shape, Rank.R4);
 }
 
@@ -96,7 +96,7 @@ export function iterate1D(length: number, callback: (i: number) => void): void {
  * iterate over a 2D array.
  */
 export function iterate2D(
-  mat: Tensor<Rank> | Shape[Rank],
+  mat: Tensor<Rank> | Shape<Rank>,
   callback: (i: number, j: number) => void,
 ): void {
   mat = (Array.isArray(mat) ? mat : mat.shape) as Shape2D;
@@ -111,7 +111,7 @@ export function iterate2D(
  * iterate over a 3D array.
  */
 export function iterate3D(
-  mat: Tensor<Rank> | Shape[Rank],
+  mat: Tensor<Rank> | Shape<Rank>,
   callback: (i: number, j: number, k: number) => void,
 ): void {
   mat = (Array.isArray(mat) ? mat : mat.shape) as Shape3D;
@@ -128,7 +128,7 @@ export function iterate3D(
  * iterate over a 4D array.
  */
 export function iterate4D(
-  mat: Tensor<Rank> | Shape[Rank],
+  mat: Tensor<Rank> | Shape<Rank>,
   callback: (i: number, j: number, k: number, l: number) => void,
 ): void {
   mat = (Array.isArray(mat) ? mat : mat.shape) as Shape4D;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -28,7 +28,7 @@ export interface Backend {
   predict(
     input: Tensor<Rank>,
     layers?: number[],
-    outputShape?: Shape[keyof Shape],
+    outputShape?: Shape<Rank>,
   ): Promise<Tensor<Rank>>;
 
   /**
@@ -51,7 +51,7 @@ export type NetworkConfig = {
   /**
    * Input size of the neural network.
    */
-  size: Shape[Rank];
+  size: Shape<Rank>;
 
   /**
    * List of layers in the neural network.


### PR DESCRIPTION
This PR adds two features:
- Better type for `Shape`.
- An overload for `tensor()` to accept a `TensorLike` as a parameter.

This provides smooth interop with [@lala/appraisal](https://jsr.io/@lala/appraisal)'s ML utilities (class to categorical, softmax to class, text vectorizers, etc).

**Using `appraisal` with `netsaur` before this PR:**
```ts
const y_pre = [1, 1, 3, 1, 2, 2, 2, 1, 1, 3, 3, 3, 2, 1];
const encoder = new CategoricalEncoder();
const y = encoder.fit(y_pre).transform(y_pre, "f32");

tensor(y.data, y.shape)
```

**Usage after this PR:**
```ts
const y_pre = [1, 1, 3, 1, 2, 2, 2, 1, 1, 3, 3, 3, 2, 1];
const encoder = new CategoricalEncoder();
const y = encoder.fit(y_pre).transform(y_pre, "f32");

tensor(y)
```